### PR TITLE
Bug fixes. Viewer will not perform clear() method for CurvesList item…

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -421,7 +421,7 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
             
 if __name__ == '__main__':
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     gui = MainWindow()
     gui.show()
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):

--- a/analyser/PeakEditor.py
+++ b/analyser/PeakEditor.py
@@ -79,21 +79,30 @@ class PBWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         for ix in ixs:
             curve_plot = pg.PlotDataItem()
             curve = self.tc.df['curve'].iloc[ix]
+            # print('curve: ')
+            # print(curve)
             # if curve is None:
             #     QtGui.QMessageBox.warning(None, 'Empty Curve')
-            curve_plot.setData(curve / min(curve))
+
+            if min(curve) != 0:
+                min_curve = min(curve)
+            else:
+                min_curve = 0.00000001
+
+            curve_plot.setData(curve / min_curve)
 
             self.graphicsView.addItem(curve_plot)
 
             # peak_ixs = self.tpb.df[self.tpb.data_column].iloc[ix].index[self.tpb.df[self.tpb.data_column].iloc[ix]['label'] == 'peak'].tolist()
             try:
+                # print(self.tpb.df['peaks_bases'].iloc[ix])
                 peaks = self.tpb.df['peaks_bases'].iloc[ix]['event'][
                     self.tpb.df['peaks_bases'].iloc[ix]['label'] == 'peak'].tolist()
 
                 peaks_plot = pg.ScatterPlotItem(name='peaks', pen=None, symbol='o', size=self.brush_size,
                                                 brush=(255, 0, 0, 150))
 
-                peaks_plot.setData(peaks, np.take(curve, peaks) / min(curve))
+                peaks_plot.setData(peaks, np.take(curve, peaks) / min_curve)
 
                 bases = self.tpb.df['peaks_bases'].iloc[ix]['event'][
                     self.tpb.df['peaks_bases'].iloc[ix]['label'] == 'base'].tolist()
@@ -101,7 +110,7 @@ class PBWindow(QtWidgets.QMainWindow, Ui_MainWindow):
                 bases_plot = pg.ScatterPlotItem(name='bases', pen=None, symbol='o', size=self.brush_size,
                                                 brush=(0, 255, 0, 150))
 
-                bases_plot.setData(bases, np.take(curve, bases) / min(curve))
+                bases_plot.setData(bases, np.take(curve, bases) / min_curve)
 
                 self.graphicsView.addItem(peaks_plot)
                 self.s_plots.append(peaks_plot)

--- a/pyqtgraphCore/flowchart/library/Definitions.py
+++ b/pyqtgraphCore/flowchart/library/Definitions.py
@@ -292,6 +292,7 @@ class PeakDetect(CtrlNode):
         peaks_bases_df.reset_index()
 
         self.row_ix += 1
+        # print(peaks_bases_df)
         return peaks_bases_df
 
     def process(self, display=True, **kwargs):

--- a/pyqtgraphCore/flowchart/library/Filters.py
+++ b/pyqtgraphCore/flowchart/library/Filters.py
@@ -43,8 +43,8 @@ class ButterWorth(CtrlNode):
 
     def _func(self, x, meta):
         N = self.ctrls['order'].value()
-
-        freq = meta['fps']
+        # print('meta: ')
+        freq = 1 / meta['fps']
         divider = self.ctrls['freqDivider'].value()
 
         self.Wn = freq/divider

--- a/pyqtgraphCore/imageview/ImageView.py
+++ b/pyqtgraphCore/imageview/ImageView.py
@@ -412,6 +412,7 @@ class ImageView(QtGui.QWidget):
         self.ui.toolBox.setEnabled(b)
         self.ui.btnAddCurrEnvToProj.setEnabled(b)
 
+
         if clear_sample_id:
             self.ui.lineEdAnimalID.clear()
             self.ui.lineEdTrialID.clear()
@@ -1285,7 +1286,8 @@ class ImageView(QtGui.QWidget):
         for i in range(0, len(self.ui.listwROIs)):
             self.ui.listwROIs.item(i).setText(str(i))
 
-        self.workEnv.CurvesList[ID].clear()
+        if isinstance(self.workEnv.CurvesList[ID], np.ndarray) is False:
+            self.workEnv.CurvesList[ID].clear()
         del self.workEnv.CurvesList[ID]
 
          # Resets the color in the order of a bright rainbow, kinda.


### PR DESCRIPTION
… in the workEnv if it is an instance of np.ndarray, this happens when the CurvesList is from split-seq mode.

Also some bug fixes with the Butterworth filter node, due to creating a new universal meta format. Now does 1/fps and peak detection works properly. 
There was a bug in PeakEditor if the min val in a curve array = 0. So added if min(curve) !0: min_curve = min(curve), else min_curve = 0.00000001. Update __main__.py, PeakEditor.py, and 3 more files...